### PR TITLE
SDL_WINDOWEVENT_TAKE_FOCUS is not defined in older SDL versions.

### DIFF
--- a/tvcon/tvcon.c
+++ b/tvcon/tvcon.c
@@ -770,7 +770,9 @@ main(int argc, char *argv[])
 			case SDL_WINDOWEVENT_LEAVE:
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 			case SDL_WINDOWEVENT_FOCUS_LOST:
+#ifdef SDL_WINDOWEVENT_TAKE_FOCUS
 			case SDL_WINDOWEVENT_TAKE_FOCUS:
+#endif
 				break;
 			default:
 				/* redraw */


### PR DESCRIPTION
I get this:

```
tvcon.c:774:9: error: ‘SDL_WINDOWEVENT_TAKE_FOCUS’ undeclared (first use in this function)
    case SDL_WINDOWEVENT_TAKE_FOCUS:
```

A web search reveals this symbol is defined in SDL 2.0.5, but not 2.0.4 and earlier.